### PR TITLE
Sorry, we need to keep php 5.3 BC ATM

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
         "source": "http://git.hoa-project.net/"
     },
     "require": {
-        "hoa/core"    : "~2.0",
+        "hoa/core"    : "~1.0",
         "hoa/iterator": "~0.0",
-        "hoa/compiler": "~2.0"
+        "hoa/compiler": "~1.0"
     },
     "target-dir": "Hoa/Math",
     "autoload"  : { "psr-0": { "Hoa\\Math": "." } }


### PR DESCRIPTION
It's a problem for non finalized libs I guess but we can't upgrade our whole infrastructure in a few days... it was planned to do the migration at the end of september... it was pretty fast, too fast !

It will be a problem for Hoa/Ruler too.

So, here's what I propose:
- We need a specific `0.14.09.17` tag for any non finalized library with `~1.0` dependencies requirements, thus we can stick on this complete tag to keep php 5.3 compatibility.
- We need a specific `0.14.09.18` tag for any non finalized library with `~2.0` dependencies requirements.
