### PR TITLE
Add associative array cartesian products

### DIFF
--- a/Combinatorics/Combination/CartesianAssociativeProduct.php
+++ b/Combinatorics/Combination/CartesianAssociativeProduct.php
@@ -1,0 +1,94 @@
+<?php
+
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2014, Karoly Negyesi. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Math\Combinatorics\Combination;
+
+/**
+ * Class \Hoa\Math\Combinatorics\Combination\CartesianAssociativeProduct.
+ *
+ * Cartesian n-ary product iterator:
+ *     [
+ *       X => [1, 2],
+ *       Y => [a, b],
+ *     ]
+ *     X × Y = [ [X => 1, Y => a], [X => 1, Y => b], [X => 2, Y => a],
+ *               [X => 2, y => b] ]
+ *
+ * @author     Karoly Negyesi <karoly@negyesi.net>
+ * @copyright  Copyright © 2014 Karoly Negyesi.
+ * @license    New BSD License
+ */
+
+class CartesianAssociativeProduct extends CartesianProduct {
+
+    /**
+     * array_keys() of the input array.
+     *
+     * @var array
+     */
+    protected $_keys = [];
+
+    /**
+     * Constructor.
+     *
+     * @access  public
+     * @param   array  $array    Associative array of arrays.
+     * @return  void
+     */
+    public function __construct ( $array ) {
+
+        $this->_keys = array_keys($array);
+        $this->init($array);
+    }
+
+    /**
+     * Prepare the current value.
+     *
+     * @access  protected
+     * @return  void
+     */
+    protected function _current ( ) {
+
+        $this->_current = [];
+
+        foreach($this->_sets as $i => $set)
+            $this->_current[$this->_keys[$i]] = $set->current();
+
+        return;
+    }
+
+}

--- a/Combinatorics/Combination/CartesianProduct.php
+++ b/Combinatorics/Combination/CartesianProduct.php
@@ -103,7 +103,12 @@ class CartesianProduct implements Iterator {
      */
     public function __construct ( $set ) {
 
-        foreach(func_get_args() as $s) {
+        $this->init(func_get_args());
+    }
+
+    public function init ( $input ) {
+
+        foreach($input as $s) {
 
             if(is_array($s))
                 $s = new Iterator\Map($s);

--- a/Test/Unit/Combinatorics/Combination/CartesianAssociativeProduct.php
+++ b/Test/Unit/Combinatorics/Combination/CartesianAssociativeProduct.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Hoa\Math\Test\Unit\Sampler\Combinatorics\Combination;
+
+use Hoa\Math\Combinatorics\Combination\CartesianAssociativeProduct as CAT;
+use Hoa\Test;
+
+/**
+ * Class \Hoa\Math\Test\Unit\Sampler\Combinatorics\Combination\CartesianAssociativeProduct.
+ *
+ * Test suite of the cartesian product.
+ *
+ * @author     Karoly Negyesi <karoly@negyesi.net>
+ * @copyright  Copyright © 2014 Karoly Negyesi.
+ * @license    New BSD License
+ */
+
+class CartesianAssociativeProduct extends Test\Unit\Suite {
+
+    public function case_empty ( ) {
+
+        $this
+            ->given($iterator = new CAT([]))
+            ->when($result = iterator_to_array($iterator))
+            ->then
+                ->array($result)
+                    ->isEqualTo([[null]]);
+    }
+
+    public function case_X ( ) {
+
+        $this
+            ->given($iterator = new CAT([[1], [2], [3]]))
+            ->when($result = iterator_to_array($iterator))
+            ->then
+                ->array($result)
+                    ->isEqualTo([
+                        [1],
+                        [2],
+                        [3]
+                    ]);
+    }
+
+    public function case_X_Y ( ) {
+
+        $this
+            ->given($iterator = new CAT(['X' => [1, 2, 3], 'Y' => [4, 5, 6]]))
+            ->when($result = iterator_to_array($iterator))
+            ->then
+                ->array($result)
+                    ->isEqualTo([
+                        ['X' => 1, 'Y' => 4],
+                        ['X' => 2, 'Y' => 4],
+                        ['X' => 3, 'Y' => 4],
+
+                        ['X' => 1, 'Y' => 5],
+                        ['X' => 2, 'Y' => 5],
+                        ['X' => 3, 'Y' => 5],
+
+                        ['X' => 1, 'Y' => 6],
+                        ['X' => 2, 'Y' => 6],
+                        ['X' => 3, 'Y' => 6]
+                    ]);
+    }
+
+    public function case_X_Y_Z ( ) {
+
+        $this
+            ->given($iterator = new CAT(['X' => [1, 2, 3], 'Y' => [4, 5, 6], 'Z' => [7, 8, 9]]))
+            ->when($result = iterator_to_array($iterator))
+            ->then
+                ->array($result)
+                    ->isEqualTo([
+                        ['X' => 1, 'Y' => 4, 'Z' => 7],
+                        ['X' => 2, 'Y' => 4, 'Z' => 7],
+                        ['X' => 3, 'Y' => 4, 'Z' => 7],
+                        ['X' => 1, 'Y' => 5, 'Z' => 7],
+                        ['X' => 2, 'Y' => 5, 'Z' => 7],
+                        ['X' => 3, 'Y' => 5, 'Z' => 7],
+                        ['X' => 1, 'Y' => 6, 'Z' => 7],
+                        ['X' => 2, 'Y' => 6, 'Z' => 7],
+                        ['X' => 3, 'Y' => 6, 'Z' => 7],
+
+                        ['X' => 1, 'Y' => 4, 'Z' => 8],
+                        ['X' => 2, 'Y' => 4, 'Z' => 8],
+                        ['X' => 3, 'Y' => 4, 'Z' => 8],
+                        ['X' => 1, 'Y' => 5, 'Z' => 8],
+                        ['X' => 2, 'Y' => 5, 'Z' => 8],
+                        ['X' => 3, 'Y' => 5, 'Z' => 8],
+                        ['X' => 1, 'Y' => 6, 'Z' => 8],
+                        ['X' => 2, 'Y' => 6, 'Z' => 8],
+                        ['X' => 3, 'Y' => 6, 'Z' => 8],
+
+                        ['X' => 1, 'Y' => 4, 'Z' => 9],
+                        ['X' => 2, 'Y' => 4, 'Z' => 9],
+                        ['X' => 3, 'Y' => 4, 'Z' => 9],
+                        ['X' => 1, 'Y' => 5, 'Z' => 9],
+                        ['X' => 2, 'Y' => 5, 'Z' => 9],
+                        ['X' => 3, 'Y' => 5, 'Z' => 9],
+                        ['X' => 1, 'Y' => 6, 'Z' => 9],
+                        ['X' => 2, 'Y' => 6, 'Z' => 9],
+                        ['X' => 3, 'Y' => 6, 'Z' => 9]
+                    ]);
+    }
+
+}


### PR DESCRIPTION
This is a fascinating library to calculate cartesian products without recursion and without keeping the whole set in memory. May I ask for associative array support? If this is not desired, could you at least please consider splitting off the init function so I can add my subclass without copying the whole constructor? Thanks.