### PR TITLE
Fix valid arithmetic space definition in an expression

### DIFF
--- a/Arithmetic.pp
+++ b/Arithmetic.pp
@@ -43,7 +43,7 @@
 //
 
 
-%skip   space     \s
+%skip   space     [\x20\x09]+
 %token  bracket_  \(
 %token _bracket   \)
 %token  comma     ,


### PR DESCRIPTION
We were previously using `\s` as a valid arithmetic space. However, it includes vertical spaces, which are not valid. We then restrict this to `SPACE` (`0x20`) and `CHARACTER TABULATION` (`0x09`). It does not break current and various usages of arithmetical expressions.