### PR TITLE
Introduce context and support variables

### DIFF
--- a/Context.php
+++ b/Context.php
@@ -1,0 +1,327 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Math;
+
+use Hoa\Math;
+
+/**
+ * Class \Hoa\Math\Context.
+ *
+ * @copyright  Copyright © 2007-2015 Hoa community
+ * @license    New BSD License
+ */
+class Context
+{
+    /**
+     * List of supported functions: identifier => values as callable.
+     *
+     * @var \ArrayObject
+     */
+    protected $_functions = null;
+
+    /**
+     * List of supported constants: identifier => values.
+     *
+     * @var \ArrayObject
+     */
+    protected $_constants = null;
+
+    /**
+     * List of supported variables: identifier => values as callable.
+     *
+     * @var \ArrayObject
+     */
+    protected $_variables = null;
+
+
+
+    /**
+     * Initialize constants and functions.
+     *
+     * @return  void
+     */
+    public function __construct()
+    {
+        $this->initializeConstants();
+        $this->initializeFunctions();
+        $this->initializeVariables();
+
+        return;
+    }
+
+    /**
+     * Add a constant.
+     *
+     * @param   string  $name     Constant name.
+     * @param   mixed   $value    Value.
+     * @return  void
+     * @throws  \Hoa\Math\Exception\AlreadyDefinedConstant
+     */
+    public function addConstant($name, $value)
+    {
+        if (true === $this->_constants->offsetExists($name)) {
+            throw new Math\Exception\AlreadyDefinedConstant(
+                'Constant %s is already defined.',
+                0,
+                $name
+            );
+        }
+
+        $this->_constants[$name] = $value;
+
+        return;
+    }
+
+    /**
+     * Get a constant.
+     *
+     * @param   string  $name    Constant name.
+     * @return  mixed
+     * @throws  \Hoa\Math\Exception\UnknownConstant
+     */
+    public function getConstant($name)
+    {
+        if (false === $this->_constants->offsetExists($name)) {
+            throw new Math\Exception\UnknownConstant(
+                'Constant %s does not exist.',
+                1,
+                $name
+            );
+        }
+
+        return $this->_constants[$name];
+    }
+
+    /**
+     * Get constants.
+     *
+     * @return  \ArrayObject
+     */
+    public function getConstants()
+    {
+        return $this->_constants;
+    }
+
+    /**
+     * Add a function.
+     *
+     * @param   string  $name        Function name.
+     * @param   mixed   $callable    Callable.
+     * @return  void
+     * @throws  \Hoa\Math\Exception\UnknownFunction
+     */
+    public function addFunction($name, $callable = null)
+    {
+        if (null === $callable) {
+            if (false === function_exists($name)) {
+                throw new Math\Exception\UnknownFunction(
+                    'Function %s does not exist, cannot add it.',
+                    2,
+                    $name
+                );
+            }
+
+            $callable = $name;
+        }
+
+        $this->_functions[$name] = xcallable($callable);
+
+        return;
+    }
+
+    /**
+     * Get a function.
+     *
+     * @param   string  $name    Function name.
+     * @return  \Hoa\Core\Consistency\Xcallable
+     * @throws  \Hoa\Math\Exception\UnknownFunction
+     */
+    public function getFunction($name)
+    {
+        if (false === $this->_functions->offsetExists($name)) {
+            throw new Math\Exception\UnknownFunction(
+                'Function %s does not exist.',
+                3,
+                $name
+            );
+        }
+
+        return $this->_functions[$name];
+    }
+
+    /**
+     * Get functions.
+     *
+     * @return  \ArrayObject
+     */
+    public function getFunctions()
+    {
+        return $this->_functions;
+    }
+
+    /**
+     * Add a variable.
+     *
+     * @param   string    $name        Variable name.
+     * @param   callable  $callable    Callable.
+     * @return  void
+     */
+    public function addVariable($name, callable $callable)
+    {
+        $this->_variables[$name] = xcallable($callable);
+
+        return;
+    }
+
+    /**
+     * Get a variable.
+     *
+     * @param   string   $name    Variable name.
+     * @return  callable
+     * @throws  \Hoa\Math\Exception\UnknownVariable
+     */
+    public function getVariable($name)
+    {
+        if (false === $this->_variables->offsetExists($name)) {
+            throw new Math\Exception\UnknownVariable(
+                'Variable %s does not exist.',
+                4,
+                $name
+            );
+        }
+
+        return $this->_variables[$name]($this);
+    }
+
+    /**
+     * Get variables.
+     *
+     * @return \ArrayObject
+     */
+    public function getVariables()
+    {
+        return $this->_variables;
+    }
+
+    /**
+     * Initialize constants mapping.
+     *
+     * @return void
+     */
+    protected function initializeConstants()
+    {
+        static $_constants = null;
+
+        if (null === $_constants) {
+            $_constants = new \ArrayObject([
+                'PI'      => M_PI,
+                'PI_2'    => M_PI_2,
+                'PI_4'    => M_PI_4,
+                'E'       => M_E,
+                'SQRT_PI' => M_SQRTPI,
+                'SQRT_2'  => M_SQRT2,
+                'SQRT_3'  => M_SQRT3,
+                'LN_PI'   => M_LNPI
+            ]);
+        }
+
+        $this->_constants = $_constants;
+
+        return;
+    }
+
+    /**
+     * Initialize functions mapping.
+     *
+     * @return void
+     */
+    protected function initializeFunctions()
+    {
+        static $_functions = null;
+
+        if (null === $_functions) {
+            $average = function () {
+                $arguments = func_get_args();
+
+                return array_sum($arguments) / count($arguments);
+            };
+
+            $_functions = new \ArrayObject([
+                'abs'     => xcallable('abs'),
+                'acos'    => xcallable('acos'),
+                'asin'    => xcallable('asin'),
+                'atan'    => xcallable('atan'),
+                'average' => xcallable($average),
+                'avg'     => xcallable($average),
+                'ceil'    => xcallable('ceil'),
+                'cos'     => xcallable('cos'),
+                'count'   => xcallable(function () { return count(func_get_args()); }),
+                'deg2rad' => xcallable('deg2rad'),
+                'exp'     => xcallable('exp'),
+                'floor'   => xcallable('floor'),
+                'ln'      => xcallable('log'),
+                'log'     => xcallable(function ($value, $base = 10) { return log($value, $base); }),
+                'max'     => xcallable('max'),
+                'min'     => xcallable('min'),
+                'pow'     => xcallable('pow'),
+                'rad2deg' => xcallable('rad2deg'),
+                'sin'     => xcallable('sin'),
+                'sqrt'    => xcallable('sqrt'),
+                'sum'     => xcallable(function () { return array_sum(func_get_args()); }),
+                'tan'     => xcallable('tan')
+            ]);
+        }
+
+        $this->_functions = $_functions;
+
+        return;
+    }
+
+    /**
+     * Initialize variables mapping.
+     *
+     * @return void
+     */
+    protected function initializeVariables()
+    {
+        if (null === $this->_variables) {
+            $this->_variables = new \ArrayObject();
+        }
+
+        return;
+    }
+}

--- a/Exception/AlreadyDefinedConstant.php
+++ b/Exception/AlreadyDefinedConstant.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Math\Exception;
+
+/**
+ * Class \Hoa\Math\Exception\UnknownConstant.
+ *
+ * Extending the \Hoa\Math\Exception class.
+ *
+ * @copyright  Copyright © 2007-2015 Hoa community
+ * @license    New BSD License
+ */
+class AlreadyDefinedConstant extends Exception
+{
+}

--- a/Exception/UnknownVariable.php
+++ b/Exception/UnknownVariable.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Math\Exception;
+
+/**
+ * Class \Hoa\Math\Exception\UnknownVariable.
+ *
+ * Extending the \Hoa\Math\Exception class.
+ *
+ * @copyright  Copyright © 2007-2015 Hoa community
+ * @license    New BSD License
+ */
+class UnknownVariable extends Exception
+{
+}

--- a/Test/Unit/Arithmetic.pp
+++ b/Test/Unit/Arithmetic.pp
@@ -42,7 +42,7 @@
 //
 
 
-%skip   space     \s
+%skip   space     [\x20\x09]+
 %token  bracket_  \(
 %token _bracket   \)
 %token  comma     ,
@@ -51,8 +51,6 @@
 %token  minus     \-
 %token  times     \*
 %token  div       /
-%token  constant  [A-Z_]+[A-Z0-9_]+
-%token  id        \w+
 
 expression:
     primary() ( ::plus:: #addition expression() )?

--- a/Test/Unit/Context.php
+++ b/Test/Unit/Context.php
@@ -1,0 +1,252 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Math\Test\Unit;
+
+use Hoa\Core;
+use Hoa\Math as LUT;
+use Hoa\Math\Context as CUT;
+use Hoa\Test;
+
+/**
+ * Class \Hoa\Math\Test\Unit\Context.
+ *
+ * Test suite of the Hoa\Math\Context class.
+ *
+ * @copyright  Copyright © 2007-2015 Hoa community
+ * @license    New BSD License
+ */
+class Context extends Test\Unit\Suite
+{
+    public function case_context_has_no_predefined_variable()
+    {
+        $this
+            ->given($context = new CUT())
+            ->when($result = $context->getVariables())
+            ->then
+                ->object($result)
+                    ->isInstanceOf('ArrayObject')
+                ->array(iterator_to_array($result))
+                    ->isEmpty();
+    }
+
+    public function case_context_exception_when_getting_unknown_variable()
+    {
+        $this
+            ->given(
+                $name    = 'foo',
+                $context = new CUT()
+            )
+            ->then
+                ->exception(function () use ($context, $name) {
+                    $context->getVariable($name);
+                })
+                    ->isInstanceOf('Hoa\Math\Exception\UnknownVariable');
+    }
+
+    public function case_context_returns_variable_value()
+    {
+        $this
+            ->given(
+                $name     = 'foo',
+                $value    = 42,
+                $callable = function() use ($value) { return $value; },
+                $context  = new CUT(),
+                $context->addVariable($name, $callable)
+            )
+            ->when($result = $context->getVariable($name))
+            ->then
+                ->integer($result)
+                    ->isEqualTo($value);
+    }
+
+    public function case_context_has_predefined_constants()
+    {
+        $this
+            ->given($context = new CUT())
+            ->when($result = $context->getConstants())
+            ->then
+                ->object($result)
+                    ->isInstanceOf('ArrayObject')
+                ->array(iterator_to_array($result))
+                    ->isEqualTo([
+                        'PI'      => M_PI,
+                        'PI_2'    => M_PI_2,
+                        'PI_4'    => M_PI_4,
+                        'E'       => M_E,
+                        'SQRT_PI' => M_SQRTPI,
+                        'SQRT_2'  => M_SQRT2,
+                        'SQRT_3'  => M_SQRT3,
+                        'LN_PI'   => M_LNPI
+                    ]);
+    }
+
+    public function case_context_exception_when_getting_unknown_constant()
+    {
+        $this
+            ->given(
+                $name    = 'FOO',
+                $context = new CUT()
+            )
+            ->then
+                ->exception(function () use ($context, $name) {
+                    $context->getConstant($name);
+                })
+                    ->isInstanceOf('Hoa\Math\Exception\UnknownConstant');
+    }
+
+    public function case_context_exception_when_setting_already_defined_constant()
+    {
+        $this
+            ->given(
+                $name    = 'PI',
+                $context = new CUT()
+            )
+            ->then
+                ->exception(function () use ($context, $name) {
+                    $context->addConstant($name, 42);
+                })
+                    ->isInstanceOf('Hoa\Math\Exception\AlreadyDefinedConstant');
+    }
+
+    public function case_context_returns_constant_value()
+    {
+        $this
+            ->given(
+                $name     = 'FOO',
+                $value    = 42,
+                $context  = new CUT(),
+                $context->addConstant($name, $value)
+            )
+            ->when($result = $context->getConstant($name))
+            ->then
+                ->variable($result)
+                    ->isEqualTo($value);
+    }
+
+    public function case_context_has_predefined_functions()
+    {
+        $this
+            ->given($context = new CUT())
+            ->when($result = $context->getFunctions())
+            ->then
+                ->object($result)
+                    ->isInstanceOf('ArrayObject')
+                ->array(iterator_to_array($result))
+                    ->hasSize(22)
+                    ->hasKey('abs')
+                    ->hasKey('acos')
+                    ->hasKey('asin')
+                    ->hasKey('atan')
+                    ->hasKey('average')
+                    ->hasKey('avg')
+                    ->hasKey('ceil')
+                    ->hasKey('cos')
+                    ->hasKey('count')
+                    ->hasKey('deg2rad')
+                    ->hasKey('exp')
+                    ->hasKey('floor')
+                    ->hasKey('ln')
+                    ->hasKey('log')
+                    ->hasKey('max')
+                    ->hasKey('min')
+                    ->hasKey('pow')
+                    ->hasKey('rad2deg')
+                    ->hasKey('sin')
+                    ->hasKey('sqrt')
+                    ->hasKey('sum')
+                    ->hasKey('tan');
+    }
+
+    public function case_context_exception_when_getting_unknown_function()
+    {
+        $this
+            ->given(
+                $name    = 'foo',
+                $context = new CUT()
+            )
+            ->then
+                ->exception(function () use ($context, $name) {
+                    $context->getFunction($name);
+                })
+                    ->isInstanceOf('Hoa\Math\Exception\UnknownFunction');
+    }
+
+    public function case_context_exception_when_setting_unknown_function()
+    {
+        $this
+            ->given(
+                $name    = 'foo',
+                $context = new CUT()
+            )
+            ->then
+                ->exception(function () use ($context, $name) {
+                    $context->addFunction($name);
+                })
+                    ->isInstanceOf('Hoa\Math\Exception\UnknownFunction');
+    }
+
+    public function case_context_returns_function_callable()
+    {
+        $this
+            ->given(
+                $name     = 'foo',
+                $callable = function() {},
+                $context  = new CUT(),
+                $context->addFunction($name, $callable)
+            )
+            ->when($result = $context->getFunction($name))
+            ->then
+                ->object($result)
+                    ->isInstanceOf('Hoa\Core\Consistency\Xcallable');
+    }
+
+    public function case_context_returns_the_right_function_callable()
+    {
+        $this
+            ->given(
+                $name     = 'foo',
+                $value    = 42,
+                $callable = function() use ($value) { return $value; },
+                $context  = new CUT(),
+                $context->addFunction($name, $callable)
+            )
+            ->when($result = $context->getFunction($name))
+            ->then
+                ->integer($result())
+                    ->isEqualTo($value);
+    }
+}


### PR DESCRIPTION
_This PR deprecates #29_

In this PR I introduced the notion of `Context` like the one we can find in [hoaproject/Ruler](https://github.com/hoaproject/Ruler). The `Context` will only be a container where we will define every constants, functions and variables we want to use in math expressions.

## About variables

As discussed in #29, the variable are to be defined as `callable`: their value might not be as static as constants so using `callable`s gives us some kind of dynamic behavior:

```php
$context->addVariable('foo', function() { return 42; });
```

This will be enough to cover many use cases I think but we can go further and reach a more dynamic behavior with _computed variables_, for example:

```php
$context->addVariable('foo', function() { return 42; });
$context->addVariable('bar', function(Context $c) { 
    $c->getVariable('foo') * $c->getConstant('PI');
});
```

This is not implement in the actual version of this PR.

What's left to do:

* [x] Introduce the `Context` class
* [x] Support variables with `addVariable`, `getVariable`, `getVariables`, 
* [x] Move the logic of `addFunction`, `getFunction`, `getFunctions`, `addConstant`, `getConstant`, `getConstants`
* [x] Tests
* [x] Overriding already defined constant is forbidden
* [x] Enable computed variable by passing the context to variables' callables
* [x] `getContext`/`setContext` on `Hoa\Math\Visitor\Arithmetic`
* [ ] **[BC break]** Remove `get(Functions?|Variables?|Constants?)` and `add(Function|Variable|Constant)` on `Hoa/Math/Visitor/Arithmetic` and exclusively use the equivalent methods on `Context`