### PR TITLE
Allow constants names to start with digits

### DIFF
--- a/Arithmetic.pp
+++ b/Arithmetic.pp
@@ -44,12 +44,12 @@
 %token  bracket_  \(
 %token _bracket   \)
 %token  comma     ,
+%token  constant  [0-9_]*[A-Z_]+[A-Z0-9_]*
 %token  number    (0|[1-9]\d*)(\.\d+)?([eE][\+\-]?\d+)?
 %token  plus      \+
 %token  minus     \-|−
 %token  times     \*|×
 %token  div       /|÷
-%token  constant  [A-Z_]+[A-Z0-9_]+
 %token  id        \w+
 
 expression:


### PR DESCRIPTION
```
$ echo -n '2_OVER_314*2' | vendor/bin/hoa compiler:pp Arithmetic.pp 0 -s

 #  namespace     token name            token value                     offset
-------------------------------------------------------------------------------
 0  default       constant              2_OVER_314                           0
 1  default       times                 *                                   10
 2  default       number                2                                   11
 3  default       EOF                                                       12

```