### PR TITLE
Fix: Remove useless return statements

### DIFF
--- a/Bin/Calc.php
+++ b/Bin/Calc.php
@@ -189,8 +189,6 @@ class Calc extends Console\Dispatcher\Kit
                     break;
             }
         } while (false !== $expression = $readline->readLine('> '));
-
-        return;
     }
 
     /**
@@ -206,8 +204,6 @@ class Calc extends Console\Dispatcher\Kit
             $this->makeUsageOptionsList([
                 'help' => 'This help.'
             ]), "\n";
-
-        return;
     }
 }
 

--- a/Combinatorics/Combination/CartesianProduct.php
+++ b/Combinatorics/Combination/CartesianProduct.php
@@ -111,8 +111,6 @@ class CartesianProduct implements Iterator
 
         $this->_max   = count($this->_sets) - 1;
         $this->_break = empty($this->_sets);
-
-        return;
     }
 
     /**
@@ -137,8 +135,6 @@ class CartesianProduct implements Iterator
         foreach ($this->_sets as $set) {
             $this->_current[] = $set->current();
         }
-
-        return;
     }
 
     /**

--- a/Combinatorics/Combination/Gamma.php
+++ b/Combinatorics/Combination/Gamma.php
@@ -121,8 +121,6 @@ class Gamma implements Iterator
     {
         $this->_n = $n;
         $this->_k = $k;
-
-        return;
     }
 
     /**
@@ -152,7 +150,6 @@ class Gamma implements Iterator
      */
     public function next()
     {
-        return;
     }
 
     /**
@@ -170,8 +167,6 @@ class Gamma implements Iterator
                               : array_fill(0, $this->_n, 0);
         $this->_o[0]    = $this->_k;
         $this->_last    = false;
-
-        return;
     }
 
     /**

--- a/Sampler/Random.php
+++ b/Sampler/Random.php
@@ -72,8 +72,6 @@ class Random extends Sampler
                 )
             );
         }
-
-        return;
     }
 
     /**

--- a/Sampler/Sampler.php
+++ b/Sampler/Sampler.php
@@ -95,8 +95,6 @@ abstract class Sampler implements Zformat\Parameterizable
         }
 
         $this->construct();
-
-        return;
     }
 
     /**
@@ -106,7 +104,6 @@ abstract class Sampler implements Zformat\Parameterizable
      */
     public function construct()
     {
-        return;
     }
 
     /**

--- a/Visitor/Arithmetic.php
+++ b/Visitor/Arithmetic.php
@@ -64,8 +64,6 @@ class Arithmetic implements Visitor\Visit
     public function __construct()
     {
         $this->initializeContext();
-
-        return;
     }
 
     /**
@@ -341,8 +339,6 @@ class Arithmetic implements Visitor\Visit
         if (null === $this->_context) {
             $this->_context = new Math\Context();
         }
-
-        return;
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] removes useless `return` statements